### PR TITLE
Use action_path to identify script

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -28,7 +28,7 @@ runs:
   steps:
     - name: Run sync script
       shell: bash
-      run: bash src/sync.sh
+      run: bash ${{ github.action_path }}/src/sync.sh
 
       env:
         SSH_KEY: ${{ inputs.ssh-key }}


### PR DESCRIPTION
This PR uses [`${{ github.action_path }}`](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#github-context) in order for this action to know where the sync script lives.